### PR TITLE
Fix #1895 by using a hash for image path

### DIFF
--- a/epub.go
+++ b/epub.go
@@ -3,6 +3,8 @@ package main
 import (
 	"archive/zip"
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"flag"
 	"fmt"
@@ -299,7 +301,8 @@ func (epub *Epub) toHtml(node xml.Node) string {
 				}
 				filename := strings.Replace(uri.Path, "/", "", -1)
 				if len(filename) > 64 {
-					filename = filename[:60] + path.Ext(filename)
+					hashpart := sha256.Sum224([]byte(uri.String()))
+					filename = hex.EncodeToString(hashpart[:]) + path.Ext(filename)
 				}
 				if !found {
 					go epub.importImage(uri, filename)


### PR DESCRIPTION
sha224 hash (56 bytes) but on the full URI to avoid collisions, with img URLs (beginnings of URIs hexacoded) or non-img URLs (same paths on different domains).